### PR TITLE
Fix codecov upload

### DIFF
--- a/ci-config/run_test_coverage.sh
+++ b/ci-config/run_test_coverage.sh
@@ -6,10 +6,6 @@
 ./run_tests.py
 if [ $? != 0 ]; then exit 1; fi
 
-if [ -x $PYTHON_COVERAGE ]; then
-    $PYTHON_COVERAGE xml -o coverage.xml
-fi
-
 if [ -r coverage.xml ]; then
     bash <(curl -s https://codecov.io/bash) -X gcov -f coverage.xml -y ci-config/codecov.yml \
 	  || echo "Codecov did not collect coverage reports."

--- a/run_tests.py
+++ b/run_tests.py
@@ -46,6 +46,7 @@ class TestApp(object):
             self.cov.stop()
             self.cov.save()
             self.cov.report()
+            self.cov.xml_report(outfile="coverage.xml")
         
         if not success:
             import sys

--- a/tests/pyre/test_units.py
+++ b/tests/pyre/test_units.py
@@ -318,6 +318,13 @@ class TestUnit(unittest.TestCase):
 
         with self.assertRaises(unit.InvalidConversion):
             x = float(3.0*SI.meter)
+
+    def test_exceptions(self):
+        value = unit.unit(3, unit.unit._zero)
         
-        
+        x = str(unit.InvalidConversion(value))
+        x = str(unit.InvalidOperation("*", value, value))
+        x = str(unit.IncompatibleUnits("*", value, value))
+
+
 # End of file


### PR DESCRIPTION
Generate `coverage.xml` in `run_tests.py` using python-coverage API so code coverage bash script doesn't depend on name of python-coverage executable.

Also added testing of exception strings for units.