### PR TITLE
Update to Python 3

### DIFF
--- a/ez_setup/__init__.py
+++ b/ez_setup/__init__.py
@@ -139,7 +139,7 @@ def download_setuptools(
     with a '/'). `to_dir` is the directory where the egg will be downloaded.
     `delay` is the number of seconds to pause before an actual download attempt.
     """
-    import urllib2
+    import urllib.request
     import shutil
     egg_name = "setuptools-%s-py%s.egg" % (version, sys.version[:3])
     url = download_base + egg_name
@@ -168,7 +168,7 @@ and place it in this directory before rerunning this script.)
                 from time import sleep
                 sleep(delay)
             log.warn("Downloading %s", url)
-            src = urllib2.urlopen(url)
+            src = urllib.request.urlopen(url)
             # Read/write all in one block, so we don't create a corrupt file
             # if the download is interrupted.
             data = _validate_md5(egg_name, src.read())

--- a/journal/__init__.py
+++ b/journal/__init__.py
@@ -161,7 +161,6 @@ _theJournal = None
 register()
         
 # version
-__version__ = "0.8.1"
-__id__ = "$Id: __init__.py,v 1.5 2005/03/14 07:32:55 aivazis Exp $"
+__version__ = "0.9.0"
 
 #  End of file 

--- a/journal/colors/ColorANSI.py
+++ b/journal/colors/ColorANSI.py
@@ -18,7 +18,7 @@ $Id: ColorANSI.py,v 1.10 2004/11/04 07:58:16 fperez Exp $"""
 __all__ = ['TermColors', 'InputTermColors', 'ColorScheme', 'ColorSchemeTable']
 
 import os
-from UserDict import UserDict
+from collections import UserDict
 
 #from IPython.Struct import Struct
 

--- a/opal/applications/CGIParser.py
+++ b/opal/applications/CGIParser.py
@@ -12,8 +12,7 @@
 #
 
 
-
-import urllib
+import urllib.parse
 
 
 class CGIParser(object):
@@ -74,11 +73,11 @@ class CGIParser(object):
         if len(children) == 1:
             for key in children[0]:
                 key = key.strip()
-                node.setProperty(key, urllib.unquote(value), self.locator)
+                node.setProperty(key, urllib.parse.unquote(value), self.locator)
             return
 
         for key in children[0]:
-            self._storeValue(node.getNode(key), children[1:], urllib.unquote(value))
+            self._storeValue(node.getNode(key), children[1:], urllib.parse.unquote(value))
 
         return
 

--- a/pyre/__init__.py
+++ b/pyre/__init__.py
@@ -18,8 +18,7 @@ def copyright():
 
 
 # version
-__version__ = "0.8.1"
-__id__ = "$Id: __init__.py,v 1.1.1.1 2005/03/08 16:13:40 aivazis Exp $"
+__version__ = "0.9.0"
 
 
 

--- a/pyre/db/Table.py
+++ b/pyre/db/Table.py
@@ -12,59 +12,48 @@
 #
 
 
-
 from pyre.parsing.locators.Traceable import Traceable
 
+from .Schemer import Schemer
 
-class Table(Traceable):
 
+class Table(Traceable, metaclass=Schemer):
 
     def getValues(self):
-        return [ self._priv_columns.get(name) for name in self._columnRegistry ]
-
+        return [self._priv_columns.get(name) for name in self._columnRegistry]
 
     def getWriteableValues(self):
-        return [ self._priv_columns.get(name) for name in self._writeable ]
-
+        return [self._priv_columns.get(name) for name in self._writeable]
 
     def getColumnNames(self):
         return list(self._columnRegistry.keys())
 
-
     def getWriteableColumnNames(self):
         return self._writeable
 
-
     def __init__(self):
         Traceable.__init__(self)
-        
+
         # local storage for the descriptors created by the various traits
         self._priv_columns = {}
 
         return
 
-
     # the low level interface
+
     def _getColumnValue(self, name):
         return self._priv_columns[name]
-
 
     def _setColumnValue(self, name, value):
         self._priv_columns[name] = value
         return value
-
 
     # column registries
     _writeable = []
     _columnRegistry = {}
 
 
-    # metaclass
-    from .Schemer import Schemer
-    __metaclass__ = Schemer
-
-
 # version
 __id__ = "$Id: Table.py,v 1.4 2005/04/07 22:16:36 aivazis Exp $"
 
-# End of file 
+# End of file

--- a/pyre/inventory/Configurable.py
+++ b/pyre/inventory/Configurable.py
@@ -12,11 +12,12 @@
 #
 
 
-
 from pyre.parsing.locators.Traceable import Traceable
 
+from .ConfigurableClass import ConfigurableClass
 
-class Configurable(Traceable):
+
+class Configurable(Traceable, metaclass=ConfigurableClass):
 
     # lifecycle management
     def init(self):
@@ -379,10 +380,6 @@ class Configurable(Traceable):
 
     # inventory
     from .Inventory import Inventory
-
-    # metaclass
-    from .ConfigurableClass import ConfigurableClass
-    __metaclass__ = ConfigurableClass
 
 
 # version

--- a/pyre/inventory/Facility.py
+++ b/pyre/inventory/Facility.py
@@ -51,7 +51,7 @@ class Facility(Trait, metaclass=Interface):
         if not self.default in [None, Uninit]:
             component = self.default
             # if we got a string, resolve
-            if isinstance(component, basestring):
+            if isinstance(component, str):
                 component, loc = self._retrieveComponent(instance, component)
                 locator = pyre.parsing.locators.chain(loc, locator)
 
@@ -86,7 +86,7 @@ class Facility(Trait, metaclass=Interface):
         return None, None
 
     def _set(self, instance, component, locator):
-        if isinstance(component, basestring):
+        if isinstance(component, str):
             component, source = self._retrieveComponent(instance, component)
 
             import pyre.parsing.locators

--- a/pyre/inventory/Facility.py
+++ b/pyre/inventory/Facility.py
@@ -12,12 +12,13 @@
 #
 
 
-
-from .Trait import Trait
 from pyre.inventory import Uninit
 
+from .Trait import Trait
+from .Interface import Interface
 
-class Facility(Trait):
+
+class Facility(Trait, metaclass=Interface):
 
     def __init__(self, name, family=None, default=Uninit, factory=None, args=(), meta=None,
                  vault=None):
@@ -199,10 +200,6 @@ class Facility(Trait):
 
     # interface registry
     _interfaceRegistry = {}
-
-    # metaclass
-    from .Interface import Interface
-    __metaclass__ = Interface
 
 
 # version

--- a/pyre/inventory/FacilityArrayFacility.py
+++ b/pyre/inventory/FacilityArrayFacility.py
@@ -48,7 +48,7 @@ class FacilityArrayFacility(Facility):
         return fa, locator
 
     def _cast(self, text):
-        if isinstance(text, basestring):
+        if isinstance(text, str):
             if text and text[0] in '[({':
                 text = text[1:]
             if text and text[-1] in '])}':

--- a/pyre/inventory/FacilityArrayFacility.py
+++ b/pyre/inventory/FacilityArrayFacility.py
@@ -11,18 +11,15 @@
 #
 
 
-
 from pyre.inventory.Facility import Facility
 
 
 class FacilityArrayFacility(Facility):
 
-
     def __init__(self, name, itemFactory, **kwds):
         Facility.__init__(self, name=name, **kwds)
         self.itemFactory = itemFactory
         return
-
 
     def _retrieveComponent(self, instance, componentName):
         facilityNames = self._cast(componentName)
@@ -38,11 +35,10 @@ class FacilityArrayFacility(Facility):
 
         from .Inventory import Inventory
         from pyre.components.Component import Component
-        
-        Inventory = Inventory.__metaclass__("FacilityArray.Inventory", (Component.Inventory,), dict)
+        Inventory = type(Inventory)("FacilityArray.Inventory", (Component.Inventory,), dict)
 
         dict = {'Inventory': Inventory}
-        FacilityArray = Component.__metaclass__("FacilityArray", (Component,), dict)
+        FacilityArray = type(Component)("FacilityArray", (Component,), dict)
         fa = FacilityArray(self.name)
         fa.Inventory._facilityOrder = facilityOrder
 
@@ -51,14 +47,13 @@ class FacilityArrayFacility(Facility):
 
         return fa, locator
 
-
     def _cast(self, text):
         if isinstance(text, basestring):
             if text and text[0] in '[({':
                 text = text[1:]
             if text and text[-1] in '])}':
                 text = text[:-1]
-                
+
             value = text.split(",")
 
             # allow trailing comma
@@ -69,9 +64,8 @@ class FacilityArrayFacility(Facility):
 
         if isinstance(value, list):
             return value
-            
-        raise TypeError("facility '%s': could not convert '%s' to a list" % (self.name, text))
 
+        raise TypeError("facility '%s': could not convert '%s' to a list" % (self.name, text))
 
 
 # end of file

--- a/pyre/inventory/Inventory.py
+++ b/pyre/inventory/Inventory.py
@@ -12,10 +12,10 @@
 #
 
 
+from .Notary import Notary
 
 
-class Inventory(object):
-
+class Inventory(object, metaclass=Notary):
 
     def initializeConfiguration(self, context):
         # load my settings from the persistent store
@@ -29,7 +29,6 @@ class Inventory(object):
 
         return
 
-
     def loadConfiguration(self, filestem):
         """load the registry contained in the given pml file (without the extension)"""
 
@@ -39,10 +38,8 @@ class Inventory(object):
 
         return shelf['inventory']
 
-
     def updateConfiguration(self, registry):
         return self._priv_registry.update(registry)
-
 
     def configureProperties(self, context):
         """configure my properties using user settings in my registry"""
@@ -72,7 +69,6 @@ class Inventory(object):
                 self._priv_registry.deleteProperty(name)
 
         return
-
 
     def configureComponents(self, context):
         """configure my components using options from my registry"""
@@ -112,7 +108,6 @@ class Inventory(object):
 
         return
 
-
     def retrieveConfiguration(self, registry):
         """place the current inventory configuration in the given registry"""
 
@@ -135,9 +130,8 @@ class Inventory(object):
 
         for component in self.components():
             component.retrieveConfiguration(node)
-            
-        return registry
 
+        return registry
 
     def collectDefaults(self, registry):
         """place my default values in the given registry"""
@@ -162,7 +156,6 @@ class Inventory(object):
 
         return registry
 
-
     def collectPropertyDefaults(self, registry=None):
         """place my default values in the given registry"""
 
@@ -185,7 +178,7 @@ class Inventory(object):
                 value = self._getTraitValue(prop.name)
             except KeyError:
                 value = prop.default
-            
+
             # The 'isinstance' is a limitation of the framework: e.g.,
             # files and dimensionals to not stringify cleanly.
             # Fortunately, we are only interested in string defaults
@@ -194,7 +187,6 @@ class Inventory(object):
                 registry.setProperty(prop.name, value, locator)
 
         return registry
-
 
     def configureComponent(self, component, context, registry=None):
         """configure <component> using options from the given registry"""
@@ -220,9 +212,8 @@ class Inventory(object):
 
         return
 
-
     def retrieveComponent(
-        self, name, factory, args=(), encodings=['odb'], vault=[], extraDepositories=[]):
+            self, name, factory, args=(), encodings=['odb'], vault=[], extraDepositories=[]):
         """retrieve component <name> from the persistent store"""
 
         if extraDepositories:
@@ -232,10 +223,9 @@ class Inventory(object):
         return self._priv_curator.retrieveComponent(
             name=name, facility=factory, args=args, encodings=encodings,
             vault=vault, extraDepositories=self._priv_depositories)
-        
 
     def retrieveAllComponents(
-        self, factory, args=(), encoding='odb', vault=[], extraDepositories=[]):
+            self, factory, args=(), encoding='odb', vault=[], extraDepositories=[]):
         """retrieve all possible components for <factory> from the persistent store"""
 
         if extraDepositories:
@@ -245,7 +235,6 @@ class Inventory(object):
         return self._priv_curator.retrieveAllComponents(
             facility=factory, args=args, encoding=encoding,
             vault=vault, extraDepositories=self._priv_depositories)
-        
 
     def retrieveBuiltInComponent(self, name, factory, args=(), vault=[]):
         import pkg_resources
@@ -256,9 +245,8 @@ class Inventory(object):
             return component
         return None
 
-
     def retrieveObject(
-        self, name, symbol, encodings, vault=[], extraDepositories=[]):
+            self, name, symbol, encodings, vault=[], extraDepositories=[]):
         """retrieve object <name> from the persistent store"""
 
         if extraDepositories:
@@ -268,7 +256,6 @@ class Inventory(object):
         return self._priv_curator.retrieveObject(
             name=name, symbol=symbol, encodings=encodings,
             vault=vault, extraDepositories=self._priv_depositories)
-        
 
     def init(self):
         """initialize subcomponents"""
@@ -278,7 +265,6 @@ class Inventory(object):
 
         return
 
-
     def fini(self):
         """finalize subcomponents"""
 
@@ -287,30 +273,26 @@ class Inventory(object):
 
         return
 
-
     def showHelp(self):
         for component in self.components():
             component.showHelp()
         return
 
-
     # lower level interface
+
     def getVault(self):
         """return the address of my vault"""
         return self._priv_vault
 
-
     def setVault(self, vault):
         """set the address of my vault"""
-        assert self._priv_depositories is None # must be called before setCurator()
+        assert self._priv_depositories is None  # must be called before setCurator()
         self._priv_vault = vault
         return
-
 
     def getCurator(self):
         """return the curator that resolves my trait requests"""
         return self._priv_curator
-
 
     def setCurator(self, curator):
         """set my persistent store manager and initialize my registry"""
@@ -323,21 +305,17 @@ class Inventory(object):
 
         return
 
-
     def dumpCurator(self):
         """print a description of the manager of my persistence store"""
         return self._priv_curator.dump(self._priv_depositories)
-
 
     def getDepositories(self):
         """return my private depositories"""
         return self._priv_depositories
 
-
     def retrieveShelves(self, address, extension):
         return self._priv_curator.retrieveShelves(
             address, extension, extraDepositories=self._priv_depositories)
-
 
     def getTraitDescriptor(self, traitName):
         try:
@@ -345,10 +323,9 @@ class Inventory(object):
 
         except KeyError:
             pass
-        
+
         self._forceInitialization(traitName)
         return self._getTraitDescriptor(traitName)
-
 
     def getTraitValue(self, traitName):
         try:
@@ -356,9 +333,8 @@ class Inventory(object):
 
         except KeyError:
             pass
-        
-        return self._forceInitialization(traitName)
 
+        return self._forceInitialization(traitName)
 
     def getTraitLocator(self, traitName):
         try:
@@ -366,35 +342,30 @@ class Inventory(object):
 
         except KeyError:
             pass
-        
+
         self._forceInitialization(traitName)
         return self._getTraitLocator(traitName)
-
 
     def getTrait(self, traitName):
         return self._traitRegistry[traitName]
 
-
     # accessors for the inventory items by category
+
     def properties(self):
         """return a list of my property objects"""
         return list(self._traitRegistry.values())
-
 
     def propertyNames(self):
         """return a list of the names of all my traits"""
         return list(self._traitRegistry.keys())
 
-
     def facilities(self):
         """return a list of my facility objects"""
         return list(self._facilityRegistry.values())
 
-        
     def facilityNames(self):
         """return a list of the names of all my facilities"""
         return list(self._facilityRegistry.keys())
-
 
     def components(self, context=None):
         """return a list of my components"""
@@ -417,15 +388,16 @@ class Inventory(object):
                 raise
             except Exception as error:
                 if context:
-                    import sys, traceback, pyre.parsing.locators
+                    import sys
+                    import traceback
+                    import pyre.parsing.locators
                     stackTrace = traceback.extract_tb(sys.exc_info()[2])
                     locator = pyre.parsing.locators.stackTrace(stackTrace)
                     context.error(error, locator=locator)
                 else:
                     raise
-        
-        return candidates
 
+        return candidates
 
     def __init__(self, name):
         # the name of the configurable that manages me
@@ -433,7 +405,7 @@ class Inventory(object):
 
         # the name of my vault
         self._priv_vault = []
-        
+
         # the manager of my persistent trait store
         self._priv_curator = None
 
@@ -448,22 +420,18 @@ class Inventory(object):
 
         return
 
-
     def _createDepositories(self):
         depositories = self._priv_curator.createPrivateDepositories(self._priv_name)
         return depositories
-    
 
     def _getTraitValue(self, name):
         return self._getTraitDescriptor(name).value
-
 
     def _setTraitValue(self, name, value, locator):
         descriptor = self._getTraitDescriptor(name)
         descriptor.value = value
         descriptor.locator = locator
         return
-
 
     def _initializeTraitValue(self, name, value, locator):
         descriptor = self._createTraitDescriptor()
@@ -472,29 +440,23 @@ class Inventory(object):
         self._setTraitDescriptor(name, descriptor)
         return
 
-
     def _getTraitLocator(self, name):
         return self._getTraitDescriptor(name).locator
-
 
     def _createTraitDescriptor(self):
         from .Descriptor import Descriptor
         return Descriptor()
 
-
     def _getTraitDescriptor(self, name):
         return self._priv_inventory[name]
-
 
     def _setTraitDescriptor(self, name, descriptor):
         self._priv_inventory[name] = descriptor
         return
 
-
     def _forceInitialization(self, name):
         trait = self._traitRegistry[name]
         return trait.__get__(self)
-
 
     # trait registries
     _traitRegistry = {}
@@ -503,12 +465,7 @@ class Inventory(object):
     _myTraitRegistry = {}
 
 
-    # metaclass
-    from .Notary import Notary
-    __metaclass__ = Notary
-
-
 # version
 __id__ = "$Id: Inventory.py,v 1.3 2005/03/11 06:59:08 aivazis Exp $"
 
-# End of file 
+# End of file

--- a/pyre/inventory/Inventory.py
+++ b/pyre/inventory/Inventory.py
@@ -183,7 +183,7 @@ class Inventory(object, metaclass=Notary):
             # files and dimensionals to not stringify cleanly.
             # Fortunately, we are only interested in string defaults
             # at present (for macro expansion).
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 registry.setProperty(prop.name, value, locator)
 
         return registry

--- a/pyre/inventory/cfg/Parser.py
+++ b/pyre/inventory/cfg/Parser.py
@@ -11,8 +11,7 @@
 #
 
 
-
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 import pyre.parsing.locators as locators
 from pyre.util import expandMacros
 
@@ -26,7 +25,7 @@ class Parser(SafeConfigParser):
     # from Python's ConfigParser module.  It injects proxy 'file' and
     # 'dict' objects into ConfigParser's code.  As the file is parsed,
     # the proxy objects gain control, spying upon the parsing process.
-    
+
     # We should probably write our own parser... *sigh*
 
     class FileProxy(object):
@@ -52,7 +51,7 @@ class Parser(SafeConfigParser):
             self.node = node
             self.macros = macros
             self.fp = fp
-        
+
         def __setitem__(self, trait, value):
             locator = locators.file(self.fp.name, self.fp.lineno)
             path = trait.split('.')
@@ -73,7 +72,7 @@ class Parser(SafeConfigParser):
             self.root = root
             self.macros = macros
             self.fp = Parser.FileProxy()
-        
+
         def __contains__(self, sectname):
             # Prevent 'ConfigParser' from creating section
             # dictionaries; instead, create our own.
@@ -82,7 +81,7 @@ class Parser(SafeConfigParser):
                 cursect = Parser.Section(sectname, node, self.macros, self.fp)
                 self[sectname] = cursect
             return True
-        
+
         def __setitem__(self, key, value):
             dict.__setitem__(self, key, value)
 

--- a/pyre/inventory/pml/parser/Facility.py
+++ b/pyre/inventory/pml/parser/Facility.py
@@ -12,25 +12,21 @@
 #
 
 
-import urllib
+import urllib.parse
 from .AbstractNode import AbstractNode
 
 
 class Facility(AbstractNode):
 
-
     tag = "facility"
-
 
     def notify(self, parent):
         return parent.onFacility(self)
 
-
     def content(self, content):
-        self.value += urllib.unquote(content)
+        self.value += urllib.parse.unquote(content)
         self.locator = self.document.locator
         return
-
 
     def __init__(self, document, attributes):
         AbstractNode.__init__(self, document)
@@ -38,9 +34,9 @@ class Facility(AbstractNode):
         self.value = ''
         self.locator = None
         return
-    
+
 
 # version
 __id__ = "$Id: Facility.py,v 1.1.1.1 2005/03/08 16:13:43 aivazis Exp $"
 
-# End of file 
+# End of file

--- a/pyre/inventory/pml/parser/Property.py
+++ b/pyre/inventory/pml/parser/Property.py
@@ -12,25 +12,21 @@
 #
 
 
-import urllib
+import urllib.parse
 from .AbstractNode import AbstractNode
 
 
 class Property(AbstractNode):
 
-
     tag = "property"
-
 
     def notify(self, parent):
         return parent.onProperty(self)
 
-
     def content(self, content):
-        self.value += urllib.unquote(content)
+        self.value += urllib.parse.unquote(content)
         self.locator = self.document.locator
         return
-
 
     def __init__(self, document, attributes):
         AbstractNode.__init__(self, document)
@@ -38,9 +34,9 @@ class Property(AbstractNode):
         self.value = ''
         self.locator = None
         return
-    
+
 
 # version
 __id__ = "$Id: Property.py,v 1.1.1.1 2005/03/08 16:13:43 aivazis Exp $"
 
-# End of file 
+# End of file

--- a/pyre/inventory/properties/Array.py
+++ b/pyre/inventory/properties/Array.py
@@ -28,7 +28,7 @@ class Array(Property):
         return
 
     def _cast(self, text):
-        if isinstance(text, basestring):
+        if isinstance(text, str):
             if text and text[0] in '[({':
                 text = text[1:]
             if text and text[-1] in '])}':

--- a/pyre/inventory/properties/Bool.py
+++ b/pyre/inventory/properties/Bool.py
@@ -24,7 +24,7 @@ class Bool(Property):
 
 
     def _cast(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             import pyre.util.bool
             return pyre.util.bool.bool(value)
 

--- a/pyre/inventory/properties/Dimensional.py
+++ b/pyre/inventory/properties/Dimensional.py
@@ -29,7 +29,7 @@ class Dimensional(Property):
 
     def _cast(self, value):
         candidate = value
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             import pyre.units
             parser = pyre.units.parser()
             candidate = parser.parse(value)

--- a/pyre/inventory/properties/InputFile.py
+++ b/pyre/inventory/properties/InputFile.py
@@ -23,7 +23,7 @@ class InputFile(Property):
         return
 
     def _cast(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             if value == "stdin":
                 import sys
                 value = sys.stdin

--- a/pyre/inventory/properties/List.py
+++ b/pyre/inventory/properties/List.py
@@ -26,7 +26,7 @@ class List(Property):
 
 
     def _cast(self, text):
-        if isinstance(text, basestring):
+        if isinstance(text, str):
             if text and text[0] in '[({':
                 text = text[1:]
             if text and text[-1] in '])}':

--- a/pyre/inventory/properties/OutputFile.py
+++ b/pyre/inventory/properties/OutputFile.py
@@ -23,7 +23,7 @@ class OutputFile(Property):
         return
 
     def _cast(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             if value == "stdout":
                 import sys
                 value = sys.stdout

--- a/pyre/inventory/properties/Preformatted.py
+++ b/pyre/inventory/properties/Preformatted.py
@@ -24,7 +24,7 @@ class Preformatted(Property):
 
 
     def _cast(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             return self._splitlines(value)
 
         return value

--- a/pyre/inventory/properties/Slice.py
+++ b/pyre/inventory/properties/Slice.py
@@ -25,7 +25,7 @@ class Slice(Property):
 
 
     def _cast(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             try:
                 value = pyre.util.range.sequence(value)
             except:

--- a/pyre/inventory/util.py
+++ b/pyre/inventory/util.py
@@ -94,7 +94,7 @@ def getLocatorContext(dct):
 
 
 def getNodeWithPath(node, path):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     if len(path) == 0:
         return node
@@ -103,21 +103,21 @@ def getNodeWithPath(node, path):
 
 
 def getPropertyWithPath(root, path, default=''):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     node = getNodeWithPath(root, path[:-1])
     return node.getProperty(path[-1], default)
 
 
 def getDescriptorWithPath(root, path, default=''):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     node = getNodeWithPath(root, path[:-1])
     return node.properties[path[-1]]
 
 
 def setPropertyWithPath(root, path, value, locator):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     node = getNodeWithPath(root, path[:-1])
     return node.setProperty(path[-1], value, locator)

--- a/pyre/odb/fs/CodecODB.py
+++ b/pyre/odb/fs/CodecODB.py
@@ -62,8 +62,7 @@ class CodecODB(Codec):
         """lock and then read the contents of the file into the shelf"""
 
         stream = open(shelf.name, "r")
-
-        exec(stream, shelf)
+        exec(stream.read(), shelf)
 
         return
 

--- a/pyre/schedulers/SchedulerLSF.py
+++ b/pyre/schedulers/SchedulerLSF.py
@@ -11,7 +11,6 @@
 #
 
 
-
 from .BatchScheduler import BatchScheduler
 import os
 import sys
@@ -52,22 +51,22 @@ class SchedulerLSF(BatchScheduler):
             return
 
         try:
-            from popen2 import Popen4
+            import subprocess
 
             cmd = [self.command]
             if self.wait:
                 cmd.append("-K")
             self._info.log("spawning: %s" % ' '.join(cmd))
-            child = Popen4(cmd)
+            child = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
             self._info.log("spawned process %d" % child.pid)
 
-            child.tochild.write("%s" % script)
-            child.tochild.close()
+            child.stdin.write(script.encode("utf-8"))
+            child.stdin.close()
 
             if self.wait:
                 self._info.log("Waiting for dispatch...")
 
-            for line in child.fromchild:
+            for line in child.stdout:
                 self._info.line("    " + line.rstrip())
             status = child.wait()
             self._info.log()

--- a/pyre/schedulers/SchedulerPBS.py
+++ b/pyre/schedulers/SchedulerPBS.py
@@ -11,7 +11,6 @@
 #
 
 
-
 from .BatchScheduler import BatchScheduler
 import os
 import sys
@@ -52,18 +51,17 @@ class SchedulerPBS(BatchScheduler):
             return
 
         try:
-            import os
-            from popen2 import Popen4
+            import subprocess
 
             cmd = [self.command]
             self._info.log("spawning: %s" % ' '.join(cmd))
-            child = Popen4(cmd)
+            child = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
             self._info.log("spawned process %d" % child.pid)
 
-            child.tochild.write("%s" % script)
-            child.tochild.close()
+            child.stdin.write(script.encode("utf-8"))
+            child.stdin.close()
 
-            for line in child.fromchild:
+            for line in child.stdout:
                 self._info.line("    " + line.rstrip())
             status = child.wait()
             self._info.log()

--- a/pyre/schedulers/scripts/lsf/batch.sh.odb
+++ b/pyre/schedulers/scripts/lsf/batch.sh.odb
@@ -9,7 +9,7 @@ def template():
             BatchScriptTemplate.__init__(self, "lsf")
 
         def render(self):
-            from StringIO import StringIO
+            from io import StringIO
 
             out = StringIO()
             scheduler = self.scheduler

--- a/pyre/schedulers/scripts/pbs/batch.sh.odb
+++ b/pyre/schedulers/scripts/pbs/batch.sh.odb
@@ -9,7 +9,7 @@ def template():
             BatchScriptTemplate.__init__(self, "pbs")
 
         def render(self):
-            from StringIO import StringIO
+            from io import StringIO
 
             out = StringIO()
             scheduler = self.scheduler

--- a/pyre/schedulers/scripts/sge/batch.sh.odb
+++ b/pyre/schedulers/scripts/sge/batch.sh.odb
@@ -9,7 +9,7 @@ def template():
             BatchScriptTemplate.__init__(self, "sge")
 
         def render(self):
-            from StringIO import StringIO
+            from io import StringIO
 
             out = StringIO()
             scheduler = self.scheduler

--- a/pyre/schedulers/scripts/tacc-ranger/batch.sh.odb
+++ b/pyre/schedulers/scripts/tacc-ranger/batch.sh.odb
@@ -9,7 +9,7 @@ def template():
             BatchScriptTemplate.__init__(self, "tacc-ranger")
 
         def render(self):
-            from StringIO import StringIO
+            from io import StringIO
 
             out = StringIO()
             scheduler = self.scheduler

--- a/pyre/units/unit.py
+++ b/pyre/units/unit.py
@@ -17,17 +17,14 @@ import operator
 
 class unit(object):
 
-
     _labels = ('m', 'kg', 's', 'A', 'K', 'mol', 'cd')
     _zero = (0,) * len(_labels)
     _negativeOne = (-1, ) * len(_labels)
-
 
     def __init__(self, value, derivation):
         self.value = value
         self.derivation = derivation
         return
-
 
     def __add__(self, other):
         if not self.derivation == other.derivation:
@@ -35,18 +32,16 @@ class unit(object):
 
         return unit(self.value + other.value, self.derivation)
 
-
     def __sub__(self, other):
         if not self.derivation == other.derivation:
             raise IncompatibleUnits("subtract", self, other)
 
         return unit(self.value - other.value, self.derivation)
 
-
     def __mul__(self, other):
         if isinstance(other, type(0)) or isinstance(other, type(0.0)):
-            return unit(other*self.value, self.derivation)
-        
+            return unit(other * self.value, self.derivation)
+
         value = self.value * other.value
         derivation = tuple(map(operator.add, self.derivation, other.derivation))
 
@@ -55,11 +50,10 @@ class unit(object):
 
         return unit(value, derivation)
 
-
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, type(0)) or isinstance(other, type(0.0)):
-            return unit(self.value/other, self.derivation)
-        
+            return unit(self.value / other, self.derivation)
+
         value = self.value / other.value
         derivation = tuple(map(operator.sub, self.derivation, other.derivation))
 
@@ -68,75 +62,79 @@ class unit(object):
 
         return unit(value, derivation)
 
-
     def __pow__(self, other):
         if not isinstance(other, type(0)) and not isinstance(other, type(0.0)):
             raise InvalidOperation("**", self, other)
 
         value = self.value ** other
-        derivation = tuple(map(operator.mul, [other]*7, self.derivation))
+        derivation = tuple(map(operator.mul, [other] * 7, self.derivation))
 
         return unit(value, derivation)
-        
 
     def __pos__(self): return self
 
-
     def __neg__(self): return unit(-self.value, self.derivation)
-
 
     def __abs__(self): return unit(abs(self.value), self.derivation)
 
-
     def __invert__(self):
-        value = 1./self.value
+        value = 1. / self.value
         derivation = tuple(map(operator.mul, self._negativeOne, self.derivation))
         return unit(value, derivation)
-
 
     def __rmul__(self, other):
         if not isinstance(other, type(0)) and not isinstance(other, type(0.0)):
             raise InvalidOperation("*", other, self)
 
-        return unit(other*self.value, self.derivation)
+        return unit(other * self.value, self.derivation)
 
-
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if not isinstance(other, type(0)) and not isinstance(other, type(0.0)):
             raise InvalidOperation("/", other, self)
 
-        value = other/self.value
+        value = other / self.value
         derivation = tuple(map(operator.mul, self._negativeOne, self.derivation))
-        
+
         return unit(value, derivation)
 
-
     def __float__(self):
-        if self.derivation == self._zero: return self.value
+        if self.derivation == self._zero:
+            return self.value
         raise InvalidConversion(self)
 
+    def __eq__(self, other):
+        return self.value == other.value
 
-    def __cmp__(self, other):
-        return cmp(self.value, other.value)
-            
+    def __ne__(self, other):
+        return self.value != other.value
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+    def __le__(self, other):
+        return self.value <= other.value
+
+    def __gt__(self, other):
+        return self.value > other.value
+
+    def __ge__(self, other):
+        return self.value >= other.value
 
     def __str__(self):
-        str = "%g" % self.value 
+        str = "%g" % self.value
         derivation = self._strDerivation()
         if not derivation:
             return str
 
         return str + "*" + derivation
-
 
     def __repr__(self):
-        str = "%g" % self.value 
+        str = "%g" % self.value
         derivation = self._strDerivation()
         if not derivation:
             return str
 
         return str + "*" + derivation
-
 
     def _strDerivation(self):
         return _strDerivation(self._labels, self.derivation)
@@ -148,15 +146,17 @@ one = dimensionless = unit(1, unit._zero)
 
 
 # helpers
-                          
+
 def _strDerivation(labels, exponents):
     dimensions = [_f for _f in map(_strUnit, labels, exponents) if _f]
     return "*".join(dimensions)
 
 
 def _strUnit(label, exponent):
-    if exponent == 0: return None
-    if exponent == 1: return label
+    if exponent == 0:
+        return None
+    if exponent == 1:
+        return label
     return label + "**%g" % exponent
 
 
@@ -168,9 +168,8 @@ class InvalidConversion(Exception):
         self._op = operand
         return
 
-
     def __str__(self):
-        str =  "dimensional quantities ('%s') " % self._op._strDerivation()
+        str = "dimensional quantities ('%s') " % self._op._strDerivation()
         str = str + "cannot be converted to scalars"
         return str
 
@@ -182,7 +181,6 @@ class InvalidOperation(Exception):
         self._op1 = operand1
         self._op2 = operand2
         return
-
 
     def __str__(self):
         str = "Invalid expression: %s %s %s" % (self._op1, self._op, self._op2)
@@ -197,12 +195,11 @@ class IncompatibleUnits(Exception):
         self._op2 = operand2
         return
 
-
     def __str__(self):
         str = "Cannot %s quanitites with units of '%s' and '%s'" % \
               (self._op, self._op1._strDerivation(), self._op2._strDerivation())
         return str
-    
+
 
 # version
 __id__ = "$Id: unit.py,v 1.1.1.1 2005/03/08 16:13:42 aivazis Exp $"

--- a/pyre/xml/Document.py
+++ b/pyre/xml/Document.py
@@ -12,33 +12,25 @@
 #
 
 
-
 from .AbstractDocument import AbstractDocument
+from .DTDBuilder import DTDBuilder
 
 
-class Document(AbstractDocument):
-
+class Document(AbstractDocument, metaclass=DTDBuilder):
 
     tags = []
 
-
     # the metaclass has prepared a look up table of nested tags
+
     def node(self, tag, attributes):
         return self._mydtd[tag](self, attributes)
-
 
     def __init__(self, source):
         AbstractDocument.__init__(self, source)
         return
 
 
-    # build the lookup table
-    from .DTDBuilder import DTDBuilder
-    __metaclass__ = DTDBuilder
-    del DTDBuilder
-
-
 # version
 __id__ = "$Id: Document.py,v 1.1.1.1 2005/03/08 16:13:41 aivazis Exp $"
 
-# End of file 
+# End of file

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except AssertionError:
 setup(
     
     name = 'pythia', 
-    version = '0.8.1.18',
+    version = '0.9.0',
 
     scripts = ['bin/idd.py', 'bin/ipad.py', 'bin/journald.py'],
 
@@ -50,7 +50,8 @@ setup(
     },
     
     author = 'Michael A.G. Aivazis',
-    author_email = 'aivazis@caltech.edu',
+    maintainer = 'Brad Aagaard',
+    maintainer_email = 'baagaard@usgs.gov',
     description = 'An extensible, object-oriented framework for specifying and staging complex, multi-physics simulations.',
     license = 'BSD',
     url = 'http://www.geodynamics.org/cig/software/pythia/',

--- a/tests/pyre/pyreapp_settings.cfg
+++ b/tests/pyre/pyreapp_settings.cfg
@@ -15,8 +15,6 @@ facility_array.five = complex-facility
 
 [pyreapp.simple_facility]
 simple_int = 11
-simple_float = -0.1
-simple_string = Hello
 
 [pyreapp.facility_array.four]
 simple_int = 4
@@ -35,3 +33,8 @@ complex_facility.simple_string = jive five
 simple_int = 6
 simple_float = 6.6
 simple_string = sixty
+
+# Test merging of duplicate sections
+[pyreapp.simple_facility]
+simple_float = -0.1
+simple_string = Hello

--- a/tests/pyre/test_schedulers.py
+++ b/tests/pyre/test_schedulers.py
@@ -166,8 +166,7 @@ class TestLSF(TestScheduler):
 
     def test_schedule(self):
         self.run_app()
-        with self.assertRaises(SystemExit):
-            self.scheduler.schedule(self.job)
+        self.scheduler.schedule(self.job)
 
 
 class TestPBS(TestScheduler):
@@ -198,8 +197,7 @@ class TestPBS(TestScheduler):
 
     def test_schedule(self):
         self.run_app()
-        with self.assertRaises(SystemExit):
-            self.scheduler.schedule(self.job)
+        self.scheduler.schedule(self.job)
 
 
 class TestSGE(TestScheduler):

--- a/tests/pyre/test_units.py
+++ b/tests/pyre/test_units.py
@@ -295,11 +295,34 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(-2 * SI.meter, ~1 * SI.meter)
 
     def test_cmp(self):
+        # Equal
         self.assertTrue(5.0 * SI.meter == 2.0 * SI.meter + 3.0 * SI.meter)
         self.assertTrue(3.0 * SI.meter / SI.second == 1.0 * SI.meter / SI.second + 2.0 * SI.meter / SI.second)
         self.assertTrue(22.0 * SI.mega * SI.pascal == 15.0e+6 * SI.pascal + 7.0 * SI.mega * SI.pascal)
         self.assertTrue(1.0 * SI.meter == 1.0 * SI.second)
         self.assertFalse(1.0 * SI.meter == 2.0 * SI.meter)
+
+        # Not equal
+        self.assertFalse(1.0 * SI.meter != 1.0 * SI.second)
+        self.assertTrue(1.0 * SI.meter != 2.0 * SI.meter)
+
+        # Less than
+        self.assertTrue(2.0 * SI.meter < 2.1 * SI.meter)
+        self.assertFalse(2.1 * SI.meter < 2.0 * SI.meter)
+
+        # Less than equal
+        self.assertTrue(2.0 * SI.meter <= 2.1 * SI.meter)
+        self.assertTrue(2.0 * SI.meter <= 2.0 * SI.meter)
+        self.assertFalse(2.1 * SI.meter <= 2.0 * SI.meter)
+
+        # Greater than
+        self.assertTrue(2.1 * SI.meter > 2.0 * SI.meter)
+        self.assertFalse(2.0 * SI.meter > 2.1 * SI.meter)
+
+        # Greater than equal
+        self.assertTrue(2.1 * SI.meter >= 2.0 * SI.meter)
+        self.assertTrue(2.0 * SI.meter >= 2.0 * SI.meter)
+        self.assertFalse(2.0 * SI.meter >= 2.1 * SI.meter)
 
     def test_str(self):
         self.assertEqual("5*m", str(5.0 * SI.meter))


### PR DESCRIPTION
Updates for Python 3 (breaks compatibility with Python 2). Increment version number to 0.9.0.

* Update .cfg parser
* Update use of metaclass
* Fix unit divisions and comparisons
* Fix UserDict import (now in collections).
* Replace basestring with str.
* Replace popen2.Popen4 with subprocess.Popen.
* Fix StringIO import; StringIO is now in io module.
* Fix urllib; use urllib.parse.unquote() and urllib.request.urlopen().
* Allow duplicate sections in .cfg files; `cfg/Parser` will merge results.

Closes #4 