### PR TITLE
Add application pyre_doc.py for showing help for Pyre components.

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,7 +1,8 @@
 bin_SCRIPTS = \
 	idd.py \
 	ipad.py \
-	journald.py
+	journald.py \
+	pyre_doc.py
 
 
 # End of file 

--- a/bin/pyre_doc.py
+++ b/bin/pyre_doc.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env nemesis
+
+from importlib import import_module
+import inspect
+import types
+import argparse
+
+class App():
+    """Application to print help for Pyre components, including facilities and properties.
+    """
+
+    def main(self):
+        """Application entry point.
+        """
+        args = self._parse_command_line()
+        try:
+            base = import_module(args.path)
+            if base.__doc__:
+                print(base.__doc__)
+            else:
+                print("No help available for module {:s}.".format(base.__name__))
+            if args.short:
+                return
+            print()
+        except ImportError:
+            base = import_module(".".join(args.path.split(".")[:-1]))
+
+        cls_name = args.path.split(".")[-1]
+        if self._has_class(base, cls_name):
+            cls_obj = getattr(base, cls_name)()
+            if cls_obj.__doc__:
+                print(f"class {cls_name}")
+                print(cls_obj.__doc__)
+            else:
+                print("No help available for {:s}.".format(cls_name))
+            if args.short:
+                return
+
+            if App._has_function(cls_obj, "showComponents"):
+                cls_obj.showComponents()
+            if App._has_function(cls_obj, "showProperties"):
+                cls_obj.showProperties()
+
+    def _parse_command_line(self):
+        """Parse command line arguments.
+        """
+        description = "Show help for module or object at a given path. If path is for a module, show help " \
+            "for class of same name. If the object is a Pyre component, then show Pyre facilities and properties."
+        parser = argparse.ArgumentParser(description=description)
+        parser.add_argument("path", metavar="OBJECT", type=str, 
+            help="Path to module or object for help.")
+        parser.add_argument("--short", action="store_true", dest="short", default=False,
+            help="Only show help for module or object at path. Do not show Pyre components or properties.")
+        return parser.parse_args()
+
+    @staticmethod
+    def _has_function(obj, name):
+        """Return True if obj has function name."""
+        return hasattr(obj, name) and type(inspect.getattr_static(obj, name)) == types.FunctionType
+
+    @staticmethod
+    def _has_class(obj, name):
+        """Return True if obj has class name."""
+        return hasattr(obj, name) and inspect.isclass(inspect.getattr_static(obj, name))
+
+
+if __name__ == "__main__":
+    App().main()

--- a/tests/pytests/Makefile.am
+++ b/tests/pytests/Makefile.am
@@ -24,6 +24,7 @@ noinst_PYTHON = \
 	pyre/test_inventory.py \
 	pyre/test_schedulers.py \
 	pyre/test_units.py \
+	pyre/test_pyredoc.py \
 	pyre/test_nemesis.py
 
 

--- a/tests/pytests/pyre/test_pyredoc.py
+++ b/tests/pytests/pyre/test_pyredoc.py
@@ -1,0 +1,107 @@
+# ======================================================================
+#
+# Brad T. Aagaard, U.S. Geological Survey
+#
+# This code was developed as part of the Computational Infrastructure
+# for Geodynamics (http://geodynamics.org).
+#
+# Copyright (c) 2010-2017 University of California, Davis
+#
+# See COPYING for license information.
+#
+# ======================================================================
+#
+
+import unittest
+import os
+import subprocess
+
+COLORCONSOLE_OUTPUT = \
+"""No help available for module pythia.journal.components.ColorConsole.
+
+No help available for ColorConsole.
+facilities of 'console':
+    renderer=<component name>: the facility that controls how the messages are formatted
+        current value: 'renderer', from {default}
+        configurable as: renderer
+properties of 'console':
+    help=<bool>: prints a screen that describes my traits
+        default value: False
+        current value: False, from {default}
+    help-components=<bool>: prints a screen that describes my subcomponents
+        default value: False
+        current value: False, from {default}
+    help-persistence=<bool>: prints a screen that describes my persistent store
+        default value: False
+        current value: False, from {default}
+    help-properties=<bool>: prints a screen that describes my properties
+        default value: False
+        current value: False, from {default}
+"""
+
+SCHEDULERLSF_OUTPUT = \
+"""No help available for module pythia.pyre.schedulers.SchedulerLSF.
+
+No help available for SchedulerLSF.
+facilities of 'lsf':
+properties of 'lsf':
+    bsub-options=<list>: (no documentation available)
+        default value: []
+        current value: [], from {default}
+    command=<str>: (no documentation available)
+        default value: 'bsub'
+        current value: 'bsub', from {default}
+    dry=<bool>: don't actually run the job; just print the batch script
+        default value: False
+        current value: False, from {default}
+    help=<bool>: prints a screen that describes my traits
+        default value: False
+        current value: False, from {default}
+    help-components=<bool>: prints a screen that describes my subcomponents
+        default value: False
+        current value: False, from {default}
+    help-persistence=<bool>: prints a screen that describes my persistent store
+        default value: False
+        current value: False, from {default}
+    help-properties=<bool>: prints a screen that describes my properties
+        default value: False
+        current value: False, from {default}
+    shell=<str>: shell for #! line of batch scripts
+        default value: '/bin/sh'
+        current value: '/bin/sh', from {default}
+    wait=<bool>: wait for the job to finish
+        default value: False
+        current value: False, from {default}
+"""
+
+class TestPyreDoc(unittest.TestCase):
+
+    def test_colorconsole(self):
+        process = subprocess.run(["pyre_doc.py", "pythia.journal.components.ColorConsole"], stdout=subprocess.PIPE)
+        linesE = COLORCONSOLE_OUTPUT.split("\n")
+        lines = process.stdout.decode("utf-8").split("\n")
+        self.assertEqual(len(linesE), len(lines))
+        for lineE, line in zip(linesE, lines):
+            self.assertEqual(lineE, line)
+
+    def test_schedulerlsf(self):
+        process = subprocess.run(["pyre_doc.py", "pythia.pyre.schedulers.SchedulerLSF"], stdout=subprocess.PIPE)
+        linesE = SCHEDULERLSF_OUTPUT.split("\n")
+        lines = process.stdout.decode("utf-8").split("\n")
+        self.assertEqual(len(linesE), len(lines))
+        for lineE, line in zip(linesE, lines):
+            self.assertEqual(lineE, line)
+
+
+def test_classes():
+    return [TestPyreDoc]
+
+
+if __name__ == "__main__":
+    suite = unittest.TestSuite()
+    for cls in test_classes():
+        suite.addTest(unittest.makeSuite(cls))
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+# End of file

--- a/tests/pytests/test_pythia.py
+++ b/tests/pytests/test_pythia.py
@@ -76,6 +76,7 @@ class TestApp(object):
         import pyre.test_units
         import pyre.test_inventory
         import pyre.test_schedulers
+        import pyre.test_pyredoc
         import pyre.test_nemesis
         import journal.test_channels
         import journal.test_devices
@@ -86,6 +87,7 @@ class TestApp(object):
             pyre.test_units,
             pyre.test_inventory,
             pyre.test_schedulers,
+            pyre.test_pyredoc,
             pyre.test_nemesis,
             journal.test_channels,
             journal.test_devices,


### PR DESCRIPTION
`pyre_doc.py` provides an easy way to get help for Pyre components, including a list of properties and facilities with their default values.

Closes #41 