### PR TITLE
Add ability to write journal location to std::ostream

### DIFF
--- a/libsrc/pythia/journal/manipulators.h
+++ b/libsrc/pythia/journal/manipulators.h
@@ -99,6 +99,16 @@ inline pythia::journal::Diagnostic & operator<< (pythia::journal::Diagnostic & s
     return (*m._f)(s, m._file, m._line, m._function);
 }
 
+// Utility functions for getting location in C++
+
+inline std::ostream& operator<<(std::ostream& s, pythia::journal::loc2_t loc) {
+  return s << " >> " << loc._file << ":" << loc._line << ":<unknown>\n";
+}
+
+inline std::ostream& operator<<(std::ostream& s, pythia::journal::loc3_t loc) {
+    return s << " >> " << loc._file << ":" << loc._line << ":" << loc._function << "\n";
+}
+
 
 // forward declarations
 namespace pythia {

--- a/tests/libtests/journal/TestDiagnostics.cc
+++ b/tests/libtests/journal/TestDiagnostics.cc
@@ -18,6 +18,7 @@ class pythia::journal::TestDiagnostics : public CppUnit::TestFixture {
     CPPUNIT_TEST(testWarning);
     CPPUNIT_TEST(testError);
     CPPUNIT_TEST(testFirewall);
+    CPPUNIT_TEST(testLocator);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -33,6 +34,8 @@ public:
     void testError(void);
 
     void testFirewall(void);
+
+    void testLocator(void);
 
 }; // TestDiagnostics
 
@@ -130,6 +133,17 @@ pythia::journal::TestDiagnostics::testFirewall(void) {
 
     firewall.activate();
     CPPUNIT_ASSERT_MESSAGE("Expected activated state.", firewall.state());
+}
+
+
+// ---------------------------------------------------------------------------------
+void
+pythia::journal::TestDiagnostics::testLocator(void) {
+    std::ostringstream msg;
+    msg << pythia::journal::at(__HERE__);
+    const std::string& here = msg.str();
+    CPPUNIT_ASSERT(here.find("TestDiagnostics.cc:") < here.length());
+    CPPUNIT_ASSERT(here.find(":143") < here.length());
 }
 
 


### PR DESCRIPTION
Add `operator<<` functions to write journal location to `std::ostream`.