### PR TITLE
Create script for generating documentation pages for each Pyre component in a path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ aux-config
 configure
 .deps
 .libs
+build
 .dirstamp
 *.lo
 *.la

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,8 +1,10 @@
-bin_SCRIPTS = \
+dist_bin_SCRIPTS = \
 	idd.py \
 	ipad.py \
 	journald.py \
 	pyre_doc.py
 
+EXTRA_DIST = \
+	pyre_doc_components.py
 
 # End of file 

--- a/bin/pyre_doc_components.py
+++ b/bin/pyre_doc_components.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env nemesis
+
+"""Generate MyST flavored Markdown documentation for all Pyre components in a given path.
+"""
+
+from importlib import import_module
+import inspect
+import types
+import contextlib
+import io
+import os
+import argparse
+import pathlib
+
+from pythia.mpi.Application import Application
+from pythia.pyre.components.Component import Component
+from pythia.pyre.util.help import MarkdownMyST
+
+class App():
+    """Application to generate Markdown documentation for Pyre components.
+    """
+
+    def __init__(self):
+        """Constructor."""
+        self.toc = {}
+
+    def main(self):
+        """Application entry point.
+        """
+        args = self._parse_command_line()
+
+        if args.manual_toc:
+            import json
+            with open(args.manual_toc) as fin:
+                manual_toc = json.load(fin)
+            self.toc.update(manual_toc)
+        
+        output_path = pathlib.Path(args.output_path)
+        src_path = pathlib.Path(args.src_path)
+        for file_path in src_path.glob("**/*.py"):
+            module_path = self._get_module_path(src_path, file_path)
+            self.mod = import_module(module_path)
+            cls_name = file_path.stem
+            if App._has_class(self.mod, cls_name):
+                filename = App._get_filename(output_path, module_path)
+                print(f"Working on {filename}...")
+                self._process_class(cls_name, filename)
+        self._write_toc(output_path)
+
+    def _write_toc(self, output_path):
+        """Write table of contents.
+
+        :param output_path: Output path for Markdown pages.
+        """
+        for key,items in self.toc.items():
+            filename = pathlib.Path(key) / "index.md"
+            with open(filename, "w") as mfile:
+                self._write_subtoc(mfile, key, items)
+        filename = output_path / "index.md"
+        with open(filename, "w") as mfile:
+            self._write_maintoc(mfile, self.toc)
+        
+    @staticmethod
+    def _write_subtoc(mfile, key, items):
+        """Write 
+        """
+        items = sorted(items)
+        mfile.write(f"# {key}\n\n")
+        mfile.write(":::{toctree}\n")
+        mfile.write("---\nmaxdepth: 1\n---\n")
+        for item in items:
+            mfile.write(f"{item}.md\n")
+        mfile.write(":::\n")
+
+    @staticmethod
+    def _write_maintoc(mfile, toc):
+        mfile.write("(sec-user-components)=\n# PyLith Components\n\n")
+        mfile.write(":::{toctree}\n")
+        mfile.write("---\nmaxdepth: 2\n---\n")
+        keys = sorted(toc.keys())
+        for key in keys:
+            mfile.write(f"{key}/index.md\n")
+        mfile.write(":::\n")
+
+    def _process_class(self, cls_name, filename):
+        try:
+            cls = getattr(self.mod, cls_name)
+            if hasattr(cls, "components"):
+                cls_obj = getattr(self.mod, cls_name)()
+            else:
+                print(f"Skipping {cls_name} object. Not a Pyre component.")
+                return
+        except:
+            print(f"Skipping {cls_name} object. Could not construct object.")
+            return
+        if isinstance(cls_obj, Component) and not isinstance(cls_obj, Application):
+            file_dir = pathlib.Path(filename).parents[0]
+            file_dir.mkdir(parents=True, exist_ok=True)
+            if not file_dir.name in self.toc:
+                self.toc[file_dir.name] = []
+            self.toc[file_dir.name].append(cls_name)
+            with open(filename, "w") as mfile:
+                self._write_markdown(mfile, cls_obj, cls_name, self.mod.__name__)
+                
+    @staticmethod
+    def _write_markdown(mfile, cls_obj, cls_name, full_name):
+        """Show documentation for class with name cls_name in module."""
+        mfile.write(f"# {cls_name}\n\n")
+        mfile.write(f"Full name: `{full_name}`\n\n")
+
+        if cls_obj.__doc__:
+            mfile.write(cls_obj.__doc__)
+            mfile.write("\n\n")
+        else:
+            print(f"Component {cls_name} missing doc string.")
+
+        if App._has_function(cls_obj, "showComponents"):
+            with contextlib.redirect_stdout(io.StringIO()) as sout:
+                cls_obj.showComponents(formatter=MarkdownMyST)
+            mfile.write("## Pyre Facilities\n\n")
+            mfile.write(sout.getvalue())
+            mfile.write("\n")
+        if App._has_function(cls_obj, "showProperties"):
+            with contextlib.redirect_stdout(io.StringIO()) as sout:
+                cls_obj.showProperties(formatter=MarkdownMyST, omitHelp=True)
+            mfile.write("## Pyre Properties\n\n")
+            mfile.write(sout.getvalue())
+            mfile.write("\n")
+
+    def _parse_command_line(self):
+        """Parse command line arguments.
+        """
+        description = "Generate Markdown documentation for Pyre components."
+        parser = argparse.ArgumentParser(description=description)
+        parser.add_argument("--src-path", action="store", dest="src_path", metavar="PATH", type=str, required=True,
+            help="Path to search for Pyre components.")
+        parser.add_argument("--output-path", action="store", dest="output_path", metavar="PATH", type=str, default=".",
+            help="Path for Markdown output.")
+        parser.add_argument("--manual-toc", action="store", dest="manual_toc", metavar="FILE", type=str,
+            help="Python script with table of contents entries for manually generated pages.")
+        return parser.parse_args()
+
+    @staticmethod        
+    def _get_module_path(src_path, file_path):
+        rel_path = file_path.relative_to(src_path.parents[0])
+        module_path = ".".join(rel_path.parts)
+        return module_path.replace(".py", "")
+
+    @staticmethod
+    def _get_filename(output_path, module_path):
+        relative_path = module_path.split(".")[1:]
+        file_path = output_path / pathlib.Path(*relative_path)
+        filename = file_path.as_posix() + ".md"
+        return filename
+
+    @staticmethod
+    def _has_function(obj, name):
+        """Return True if obj has function name."""
+        return hasattr(obj, name) and type(inspect.getattr_static(obj, name)) == types.FunctionType
+
+    @staticmethod
+    def _has_class(obj, name):
+        """Return True if obj has class name."""
+        return hasattr(obj, name) and inspect.isclass(inspect.getattr_static(obj, name))
+
+
+if __name__ == "__main__":
+    App().main()

--- a/pythia/pyre/util/help.py
+++ b/pythia/pyre/util/help.py
@@ -1,0 +1,89 @@
+"""Formatters for help information used in Configurable showComponents() and showProperties().
+"""
+
+class Ascii(object):
+    """Plain ASCII text.
+    """
+
+    @staticmethod
+    def formatComponents(name, facilities):
+        """Format components information.
+
+        name: Facility name.
+        facilities: Dictionary with facilities information.
+          - name: Name of facility
+          - doc: Facility help string.
+          - descriptor: Descriptor for facility.
+        """
+        print("facilities of %r:" % name)
+        for facility in facilities:
+            print("    %s=<component name>: %s" % (facility["name"], facility["doc"]))
+            value = facility["descriptor"].value
+            locator = facility["descriptor"].locator
+            print("        current value: %r, from %s" % (value.name, locator))
+            print("        configurable as: %s" % ", ".join(value.aliases))
+
+    @staticmethod
+    def formatProperties(name, properties):
+        """Format properties information.
+
+        name: Facility name.
+        properties: Dictionary with properties information.
+          - name: Name of property
+          - doc: Property help string
+          - trait: Property trait
+          - descriptor: Descriptor for property
+        """
+        print("properties of %r:" % name)
+        for prop in properties:
+            trait = prop["trait"]
+            value = prop["descriptor"].value
+            locator = prop["descriptor"].locator
+            print("    %s=<%s>: %s" % (prop["name"], trait.type, prop["doc"]))
+            print("        default value: %r" % trait.default)
+            print("        current value: %r, from %s" % (value, locator))
+            if trait.validator:
+                print("        validator: %s" % trait.validator)
+
+
+class MarkdownMyST(object):
+    """Markedly structured text flavored Markdown.
+    """
+
+    @staticmethod
+    def formatComponents(name, facilities):
+        """Format components information.
+
+        name: Facility name.
+        facilities: Dictionary with facilities information.
+          - name: Name of facility
+          - doc: Facility help string.
+          - descriptor: Descriptor for facility.
+        """
+        for facility in facilities:
+            print("* `%s`: %s" % (facility["name"], facility["doc"]))
+            value = facility["descriptor"].value
+            locator = facility["descriptor"].locator
+            print("  - **current value**: %r, from %s" % (value.name, locator))
+            print("  - **configurable as**: %s" % ", ".join(value.aliases))
+
+    @staticmethod
+    def formatProperties(name, properties):
+        """Format properties information.
+
+        name: Facility name.
+        properties: Dictionary with properties information.
+          - name: Name of property
+          - trait: Property trait
+          - doc: Property help string
+          - descriptor: Descriptor for property
+        """
+        for prop in properties:
+            trait = prop["trait"]
+            value = prop["descriptor"].value
+            locator = prop["descriptor"].locator
+            print("* `%s`=\<%s\>: %s" % (prop["name"], trait.type, prop["doc"]))
+            print("  - **default value**: %r" % trait.default)
+            print("  - **current value**: %r, from %s" % (value, locator))
+            if trait.validator:
+                print("  - **validator**: %s" % trait.validator)

--- a/tests/pytests/Makefile.am
+++ b/tests/pytests/Makefile.am
@@ -8,7 +8,6 @@ endif
 dist_check_SCRIPTS = test_pythia.py test_mpi.py
 
 noinst_PYTHON = \
-	__init__.py \
 	journal/__init__.py \
 	journal/test_channels.py \
 	journal/test_devices.py \


### PR DESCRIPTION
Script for generating MyST flavored Markdown is used by application developers to generate documentation pages for each Pyre component in their package.